### PR TITLE
Provide Game Specific Information Legally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.12-alpine
 # copy requirements alone to speed up build time
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -49,5 +49,21 @@ chmod +x setup.sh
 ./setup.sh "$my_bot_token"
 ```
 
+### Adding Game Information
+
+It would be copyright infringement to add extensive game information to this repository, but logic to parse a file is fair game. MCG was kind enough to provide a searchable text file to backers, and if the bot is informed of that file additional commands become available. You would specify that file in the following way:
+
+```shell
+python theMoth.py --searchable_text_file /path/to/file.txt
+```
+
+### Running Unit Tests
+
+This codebase contains some unit tests, which can be executed by running the following command from the base directory:
+
+```shell
+python -m unittest discover
+```
+
 ### Credits:
 Moth logo image by <a href="https://pixabay.com/users/nika_akin-13521770/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=4658451">Nika Akin</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=4658451">Pixabay</a>.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ It would be copyright infringement to add extensive game information to this rep
 python theMoth.py --searchable_text_file /path/to/file.txt
 ```
 
+#### AI Suggestions
+
+If you further set the environment variable `OPENAI_API_KEY`, it will include a `/suggest` command that makes ChatGPT-based reccomendations based off the loaded game information.
+
 ### Running Unit Tests
 
 This codebase contains some unit tests, which can be executed by running the following command from the base directory:

--- a/ai/suggestion.py
+++ b/ai/suggestion.py
@@ -1,0 +1,58 @@
+import logging
+from game.catalog import ItemInformation
+
+
+class SuggestionClient():
+    def __init__(self, game, llm_client):
+        self.game = game
+        self.llm_client = llm_client
+
+    def suggest(self, category, prompt):
+        catalog = self.game[category]
+        prediction = self.prediction(category, prompt)
+        if prediction in catalog:
+            return catalog[prediction]
+        else:
+            return ItemInformation("AI Hallucination", f"ChatGPT hallucinated and suggested {prediction}")
+
+    def prediction(self, category, prompt):
+        return self.completion(
+            self.messages(category, prompt)
+        ).choices[0].message.content
+
+    def completion(self, messages):
+        return self.llm_client.chat.completions.create(
+            messages=messages,
+            model="gpt-4-turbo",
+        )
+
+    def messages(self, category, prompt):
+        return [
+            {
+                "role": "system",
+                "content": "\n".join([
+                    f"You are an Invisible Sun GM, tasked with selecting relevant game materials. You have been asked to select from {category} among the following:",
+                    "",
+                    *[f"{item.title}\n{item.description}\n" for item in self.game[category].values()],
+                    "",
+                    "Your response should be the title of the item you selected.",
+                ]),
+            },
+            {
+                "role": "user",
+                "content": prompt,
+            },
+        ]
+
+
+class LoggedSuggestionClient(SuggestionClient):
+    def prediction(self, category, prompt):
+        prediction = super().prediction(category, prompt)
+        logging.debug(f"Prediction {prediction}")
+        return prediction
+
+    def completion(self, messages):
+        logging.debug(f"Messages {messages}")
+        completion = super().completion(messages)
+        logging.debug(f"Completion {completion}")
+        return completion

--- a/ai/test_suggestion.py
+++ b/ai/test_suggestion.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock
+from ai.suggestion import SuggestionClient
+from game.information import GameInformation
+from game.catalog import Catalog, ItemInformation
+
+
+class SuggestionTest(TestCase):
+    def setUp(self):
+        self.llm_client = Mock()
+        self.completion = MagicMock()
+        self.llm_client.chat.completions.create.return_value = self.completion
+        self.item = ItemInformation("B", "C")
+
+        self.client = SuggestionClient(GameInformation({
+            "A": Catalog("A", {
+                "B": self.item,
+            }),
+        }), self.llm_client)
+
+    def test_suggest(self):
+        self.mock_prediction("B")
+        self.assertEqual(self.item, self.client.suggest("A", "a test message"))
+
+    def test_hallucination(self):
+        self.mock_prediction("C")
+        self.assertRegex(
+            self.client.suggest("A", "a test message").description,
+            r"C",
+        )
+
+    def mock_prediction(self, prediction):
+        self.completion.choices[0].message.content = prediction

--- a/game/case_insensitive_dict.py
+++ b/game/case_insensitive_dict.py
@@ -1,0 +1,20 @@
+class CaseInsensitiveDict(dict):
+    def __init__(self, seed):
+        self.case_sensitive = seed
+        super().__init__({
+            key.upper(): seed[key]
+            for key in seed
+        })
+
+    def __getitem__(self, k):
+        return super().__getitem__(k.upper())
+
+    def __setitem__(self, k, v):
+        self.case_sensitive[k] = v
+        super().__setitem__(k.upper(), v)
+
+    def __contains__(self, k):
+        return super().__contains__(k.upper())
+
+    def keys(self):
+        return self.case_sensitive.keys()

--- a/game/catalog.py
+++ b/game/catalog.py
@@ -37,5 +37,8 @@ class ItemInformation():
         self.title = title
         self.description = description
 
-    def __str__(self):
+    def __repr__(self):
         return f"{self.title}\n{self.description}"
+
+    def __eq__(self, o):
+        return self.title == o.title and self.description == o.description

--- a/game/catalog.py
+++ b/game/catalog.py
@@ -1,0 +1,41 @@
+import re
+import itertools
+from game.case_insensitive_dict import CaseInsensitiveDict
+from game.section import Section
+
+
+class Catalog(CaseInsensitiveDict):
+    @classmethod
+    def build(cls, section, description=None):
+        catalog = cls(description or cls.description_text(section))
+        entries = []
+        for line in section:
+            if catalog.entry_start(line):
+                entries.append(Section())
+            if entries:
+                entries[-1].append(line)
+
+        for entry in entries:
+            catalog.add_entry(entry)
+
+        return catalog
+
+    @classmethod
+    def description_text(cls, section):
+        if re.match(r"^[A-Z ]+$", section[0]):
+            section = Section(section[1:])
+        description_lines = itertools.takewhile(lambda line: line not in ["", "---"], section.strip())
+        return "\n".join([line for line in description_lines if line != "----"])
+
+    def __init__(self, description, entries=None):
+        self.description = description
+        super().__init__(entries or {})
+
+
+class ItemInformation():
+    def __init__(self, title, description):
+        self.title = title
+        self.description = description
+
+    def __str__(self):
+        return f"{self.title}\n{self.description}"

--- a/game/command_line.py
+++ b/game/command_line.py
@@ -1,0 +1,22 @@
+import pprint
+import sys
+from information import GameInformation
+from catalog import Catalog
+
+game_info = GameInformation.parse(sys.argv[1])
+if len(sys.argv) > 3:
+    if sys.argv[3] == "*":
+        items = game_info[sys.argv[2]]
+        for key in items:
+            print(key)
+            print(items[key].description, "\n")
+    else:
+        pprint.pp(game_info[sys.argv[2]][sys.argv[3]])
+elif len(sys.argv) > 2:
+    element = game_info[sys.argv[2]]
+    if isinstance(element, Catalog):
+        print(element.description)
+    else:
+        print(element)
+else:
+    pprint.pp(game_info)

--- a/game/definitions.py
+++ b/game/definitions.py
@@ -1,0 +1,13 @@
+import re
+from game.catalog import Catalog, ItemInformation
+
+
+class Definitions(Catalog):
+    def entry_start(self, line):
+        return re.search(r":", line)
+
+    def add_entry(self, lines):
+        line = lines[0]
+        (key, value) = line.split(":", 1)
+        key = re.sub(r"\s*\([A-Z]+\)$", "", key)
+        self[key] = ItemInformation(key, value.strip())

--- a/game/information.py
+++ b/game/information.py
@@ -1,0 +1,125 @@
+import re
+import itertools
+import enum
+from game.case_insensitive_dict import CaseInsensitiveDict
+from game.catalog import Catalog, ItemInformation
+from game.multiline_catalog import MultilineCatalog
+from game.section import Section
+from game.definitions import Definitions
+import random
+
+
+class GameInformation(CaseInsensitiveDict):
+    @classmethod
+    def parse(cls, filename):
+        sections = cls.parse_sections(filename)
+        return cls.build_from_sections(sections)
+
+    @classmethod
+    def build_from_sections(cls, sections):
+        info = {
+            "GAME": Catalog("General Game Information", {
+                "TITLE": ItemInformation("TITLE", sections[0][0]),
+                "PREAMBLE": ItemInformation("PREAMBLE", "\n".join(sections[1])),
+                "LICENSE": ItemInformation("LICENSE", "\n".join(sections[2])),
+            }),
+            "GLOSSARY": Definitions.build(sections[3], "General Definitions"),
+            "CANTRIPS": Definitions.build(sections[5]),
+            "CHARMS": Definitions.build(sections[6]),
+            "SIGNS": Definitions.build(sections[7]),
+            "HEXES": Definitions.build(sections[8]),
+            "MONOGRAPHS": "\n".join(sections[9]),
+            "RITUALS": MultilineCatalog.build(sections[11]),
+            "INCANTATIONS": MultilineCatalog.build(sections[13] + sections[14] + sections[15] + sections[16] + sections[17], "Incantations"),
+            "OBJECTS OF POWER": MultilineCatalog.build(sections[19], "Objects of Power"),
+            "SPELLS": MultilineCatalog.build(
+                sections[21] + sections[22] + sections[23] +
+                ["FERMATA (SPELL)"] + sections[24][1:] +
+                ["HUNT THE LOST (SPELL)"] + sections[25][1:] +
+                sections[26][1:],
+                "Spells",
+            ),
+            "ORDER": Catalog("Order Special Rules", {
+                order: ItemInformation(order, "\n".join(sections[section_index].strip()))
+                for (order, section_index) in [("MAKER", 65),
+                                               ("WEAVER", 66),
+                                               ("GOETIC", 67)]
+            }),
+            "HEART": Catalog("Heart", {
+                heart: ItemInformation(heart, "\n".join(sections[section_id][1:]))
+                for (heart, section_id) in [("GALANT", 32),
+                                            ("STOIC", 33),
+                                            ("EMPATH", 34),
+                                            ("ARDENT", 35)]
+            }),
+            "FORTE ABILITY": MultilineCatalog.build(sections[36]),
+            "SOUL": MultilineCatalog.build(sections[38], "Soul"),
+            "CHARACTER ARCS": MultilineCatalog.build(sections[40], "Character Arcs"),
+            "DISTRICTS OF SATYRINE": Catalog("Districts of Satyrine", {
+                section[0]: ItemInformation(
+                    section[0],
+                    "\n".join(section[1:]),
+                )
+                for section in sections[42:59]
+            }),
+            "CREATURES": Catalog({
+                section[0]: ItemInformation(
+                    section[0],
+                    "\n".join(section[1:]),
+                ) for section in sections[60:64]
+            }),
+            "CHARACTER SECRETS": MultilineCatalog.build(sections[69]),
+            "HOUSE SECRETS": MultilineCatalog.build(sections[70]),
+            "CHARACTER CREATION": Catalog("Character Creation", {
+                section[0]: ItemInformation(
+                    section[0],
+                    "\n".join(section[1:]),
+                ) for section in sections[71:]
+            })
+        }
+
+        info.update(cls.separate_categories(
+            MultilineCatalog.build(sections[10]),
+            ["CONJURATIONS", "INVOCATIONS", "ENCHANTMENTS"],
+        ))
+
+        info.update(cls.separate_categories(
+            MultilineCatalog.build(sections[29], "Ephemera Objects"),
+            ["EPHEMERA OBJECTS"] + [f"VANCE {size} SPELL" for size in ["ALPHA", "BETA", "OMEGA"]],
+        ))
+
+        return GameInformation(info)
+
+    @classmethod
+    def separate_categories(cls, catalog: MultilineCatalog, categories):
+        return {
+            category: catalog.only_category(category)
+            for category in categories
+        }
+
+    @classmethod
+    def parse_sections(cls, filename):
+        with open(filename) as file:
+            sections = [Section()]
+
+            for line in file.readlines():
+                line = line.strip()
+                if not sections[-1].should_include(line):
+                    sections.append(Section())
+                sections[-1].append(line)
+            return [
+                section
+                for section
+                in sections
+                if len(section.nonempty_lines()) > 0
+            ]
+
+    def categories(self):
+        return enum.StrEnum("Categories", list(self.keys()))
+
+    def lookup(self, category, item):
+        if item in self[category]:
+            return self[category][item]
+
+    def random(self, category):
+        return random.choice(list(self[category].values()))

--- a/game/information.py
+++ b/game/information.py
@@ -85,7 +85,7 @@ class GameInformation(CaseInsensitiveDict):
 
         info.update(cls.separate_categories(
             MultilineCatalog.build(sections[29], "Ephemera Objects"),
-            ["EPHEMERA OBJECTS"] + [f"VANCE {size} SPELL" for size in ["ALPHA", "BETA", "OMEGA"]],
+            ["EPHEMERA OBJECT"] + [f"VANCE {size} SPELL" for size in ["ALPHA", "BETA", "OMEGA"]],
         ))
 
         return GameInformation(info)

--- a/game/multiline_catalog.py
+++ b/game/multiline_catalog.py
@@ -1,0 +1,28 @@
+import re
+from game.catalog import Catalog, ItemInformation
+
+
+class MultilineCatalog(Catalog):
+    def only_category(self, category):
+        return MultilineCatalog(self.description, { title: self[title] for title in self if self[title].category == category })
+
+    def entry_start(self, line):
+        return re.match(r"(?P<title>^[-’A-Z ]+?)\s*\((?P<practice>[A-Z ]+)\)$", line)
+
+    def add_entry(self, lines):
+        title = self.entry_start(lines[0])[1]
+        self[title] = MultilineInformation(
+            title,
+            self.entry_start(lines[0])["practice"],
+            "\n".join(lines.strip()[1:]),
+        )
+
+
+class MultilineInformation(ItemInformation):
+    def __init__(self, title, category, description):
+        self.title = title
+        self.category = category
+        self.description = description
+
+    def __str__(self):
+        return f"{self.title} ({self.category})\n{self.description}"

--- a/game/section.py
+++ b/game/section.py
@@ -1,0 +1,25 @@
+import re
+import itertools
+
+
+class Section(list):
+    def at_paragraph_break(self):
+        return self and self[-1] == ""
+
+    def nonempty_lines(self):
+        return [
+            line
+            for line
+            in self
+            if line != ""
+        ]
+
+    def should_include(self, line):
+        return (line != "" and not re.search(r"^[A-Z, ]+$", line)) or not self.at_paragraph_break()
+
+    def strip(self):
+        is_empty_line = lambda line: line == ""
+        strip_front = lambda lines: list(itertools.dropwhile(is_empty_line, lines))
+        front_stripped = strip_front(self)
+        rear_stripped = reversed(strip_front(reversed(front_stripped)))
+        return Section(rear_stripped)

--- a/game/test_case_insensitive_dict.py
+++ b/game/test_case_insensitive_dict.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from game.case_insensitive_dict import CaseInsensitiveDict
+
+
+class CaseInsensitiveDictTest(TestCase):
+    def setUp(self):
+        self.dictionary = CaseInsensitiveDict({ "Something": "Interesting" })
+
+    def test_uppercased_lookup(self):
+        self.assertEqual(self.dictionary["SOMETHING"], "Interesting")
+
+    def test_lowercased_lookup(self):
+        self.assertEqual(self.dictionary["something"], "Interesting")
+
+    def test_contains(self):
+        self.assertIn("something", self.dictionary)
+
+    def test_assignment(self):
+        self.dictionary["new"] = "Something new"
+        self.assertEqual("Something new", self.dictionary["NEW"])
+
+    def test_init_keys(self):
+        self.assertEqual(["Something"], list(self.dictionary.keys()))
+
+    def test_set_keys(self):
+        self.dictionary["new"] = "value"
+        self.assertIn("new", self.dictionary.keys())

--- a/game/test_catalog.py
+++ b/game/test_catalog.py
@@ -1,0 +1,16 @@
+from unittest import TestCase, main
+from game.information import Section, Definitions, Catalog, GameInformation
+from game.multiline_catalog import MultilineCatalog, MultilineInformation
+from game.catalog import ItemInformation
+
+
+class CatalogTest(TestCase):
+    def test_description_text(self):
+        self.assertEqual("Two\nlines", Catalog.description_text(Section(["Two", "lines"])))
+        self.assertEqual("Section List Page", Catalog.description_text(Section(["SECTION", "", "----", "Section List Page", "---"])))
+        self.assertEqual("description", Catalog.description_text(Section(["SECTION TITLE", "description"])))
+
+
+class ItemInformationTest(TestCase):
+    def test_str(self):
+        self.assertEqual("Title\nfoo", str(ItemInformation("Title", "foo")))

--- a/game/test_definitions.py
+++ b/game/test_definitions.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+from game.definitions import Definitions
+
+class DefinitionsTest(TestCase):
+    def test_entry_start(self):
+        definitions = Definitions("", [])
+        self.assertTrue(definitions.entry_start("TERM: definition"))
+
+    def test_add_entry(self):
+        definitions = Definitions("", [])
+        definitions.add_entry(["TERM: definition"])
+        self.assertEqual("definition", definitions["TERM"].description)

--- a/game/test_information.py
+++ b/game/test_information.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+import enum
+from game.information import GameInformation
+from game.multiline_catalog import MultilineCatalog, MultilineInformation
+from game.catalog import Catalog, ItemInformation
+
+
+class GameInformationTest(TestCase):
+    def test_categories(self):
+        game = GameInformation({ "SOMETHING": {} })
+        self.assertEqual(
+            "something",
+            game.categories().SOMETHING.value,
+        )
+
+    def test_lookup(self):
+        item = ItemInformation("INTERESTING", "FOUND")
+        game = GameInformation({ "SOMETHING": { "INTERESTING": item } })
+        self.assertEqual(
+            item,
+            game.lookup("SOMETHING", "INTERESTING"),
+        )
+        self.assertIsNone(game.lookup("SOMETHING", "MISSING"))
+
+    def test_random(self):
+        item = ItemInformation("INTERESTING", "FOUND")
+        game = GameInformation({ "SOMETHING": { "INTERESTING": item } })
+        self.assertEqual(item, game.random("SOMETHING"))
+
+    def test_separate_categories(self):
+        separated = GameInformation.separate_categories(MultilineCatalog("", {
+            "A": MultilineInformation("A", "A", "A"),
+            "B": MultilineInformation("B", "B", "B"),
+            "C": MultilineInformation("C", "C", "C"),
+        }), ["A", "B", "C"])
+        self.assertIn("A", separated["A"])
+        self.assertIn("B", separated["B"])
+        self.assertIn("C", separated["C"])
+
+    def test_case_insensitive_terms(self):
+        item = ItemInformation("interesting", "Found")
+        game = GameInformation({ "something": Catalog("", { "interesting": item }) })
+        self.assertEqual(game["SOMETHING"]["INTERESTING"], item)
+        self.assertEqual(game["something"]["interesting"], item)
+        self.assertIn("interesting", game["something"])

--- a/game/test_multiline_catalog.py
+++ b/game/test_multiline_catalog.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+from game.multiline_catalog import MultilineCatalog, MultilineInformation
+from game.section import Section
+
+class MultilineCatalogTest(TestCase):
+    def test_only_category(self):
+        catalog = MultilineCatalog("description", {
+            "VALID": MultilineInformation("valid", "valid", "valid"),
+            "INVALID": MultilineInformation("invalid", "invalid", "invalid"),
+        }).only_category("valid")
+        self.assertIn("VALID", catalog)
+        self.assertNotIn("INVALID", catalog)
+
+    def test_entry_start(self):
+        practices = MultilineCatalog("", [])
+        self.assertTrue(practices.entry_start("SOMETHING (WITH SPACES)"))
+        self.assertTrue(practices.entry_start("SPECIAL’S (PRACTICE)"))
+
+    def test_add_entry(self):
+        practices = MultilineCatalog("", [])
+        practices.add_entry(Section([
+            "TITLE (PRACTICE)",
+            "description",
+        ]))
+        practice = practices["TITLE"]
+        self.assertEqual("TITLE", practice.title)
+        self.assertEqual("PRACTICE", practice.category)
+        self.assertEqual("description", practice.description)
+
+
+class MultilineInformationTest(TestCase):
+    def test_str(self):
+        self.assertEqual(
+            "Title (Category)\ndescription",
+            str(MultilineInformation("Title", "Category", "description")),
+        )

--- a/game/test_section.py
+++ b/game/test_section.py
@@ -1,0 +1,7 @@
+from unittest import TestCase
+from game.section import Section
+
+
+class SectionTest(TestCase):
+    def test_should_include(self):
+        self.assertTrue(Section(['anything']).should_include("ALL CAPS"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ bs4
 html2text
 py-cord
 requests
+openai
+

--- a/theMoth.py
+++ b/theMoth.py
@@ -7,6 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 from discord import commands
 from html2text import html2text
+import argparse
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')
 
@@ -222,5 +223,35 @@ async def roll(ctx, dice=commands.Option(str, 'Use +[num] to add Invisible Sun M
                '\nUse "/roll" to roll a single Invisible Sun die (mundane).'
                '\nTo add magic dice, use +[# of magic dice].'
                '\nFor other dice rolls, use the form [count]d[sides], +[bonus], or -[bonus]')
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-s', '--searchable_text_file')
+args = parser.parse_args()
+
+if args.searchable_text_file:
+    from game.information import GameInformation
+    game = GameInformation.parse(args.searchable_text_file)
+    category_options = commands.Option(game.categories(), "The category within the rules")
+
+    @bot.slash_command(name='lookup', description='Lookup game information available in searchable text file provided to backers')
+    async def lookup(
+            ctx,
+            category=category_options,
+            information=commands.Option(str, "The name of the information you are looking up"),
+    ):
+        return await ctx.respond(
+            str(game.lookup(category, information))
+        )
+
+    @bot.slash_command(name='random', description='Find a random entry in the provided category')
+    async def random(
+            ctx,
+            category=category_options,
+    ):
+        return await ctx.respond(
+            str(game.random(category))
+        )
+
 
 bot.run(token)

--- a/theMoth.py
+++ b/theMoth.py
@@ -5,7 +5,7 @@ import os
 import random
 import requests
 from bs4 import BeautifulSoup
-from discord import commands
+from discord import commands, ApplicationContext
 from html2text import html2text
 import argparse
 
@@ -252,6 +252,21 @@ if args.searchable_text_file:
         return await ctx.respond(
             str(game.random(category))
         )
+
+    if 'OPENAI_API_KEY' in os.environ:
+        from ai.suggestion import LoggedSuggestionClient
+        from openai import OpenAI
+        suggestion_client = LoggedSuggestionClient(game, OpenAI())
+
+        @bot.slash_command(name='suggest', description='Have AI make a suggestion')
+        async def suggest(
+                ctx: ApplicationContext,
+                category=category_options,
+                prompt=commands.Option(str, "A description to provide to AI of what you're looking for"),
+        ):
+            return await ctx.respond(
+                str(suggestion_client.suggest(category, prompt))
+            )
 
 
 bot.run(token)


### PR DESCRIPTION
I wanted a way to be able to look up information about various cards without infringing on MCG's copyright. I can't reproduce the actual game information, but fortunately they provided a searchable text file which is parseable with a little effort.

This change allows the bot to work exactly the same if a searchable text file is not provided, but will parse that file and add additional commands if it is. The basic proofs of concept are the commands `/lookup` and `/random`, but I intend them to be stepping stones to more interesting options.